### PR TITLE
Securely decrypt env and create container

### DIFF
--- a/.docker-compose.yml
+++ b/.docker-compose.yml
@@ -55,8 +55,8 @@ services:
         restart: unless-stopped
         ports:
             - "${HOST_HTTP_PORT:-80}:${CONTAINER_HTTP_PORT:-8000}"
-        volumes:
-            - ./.laravel.env:/var/www/html/.env:ro
+        env_file:
+            - ${APP_ENV_FILE}
 
 networks:
     sail:

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -98,24 +98,27 @@ deploy_application:
       export ENV_ENCRYPTED ENV_KEY
   script:
     - ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$DEPLOY_PATH'"
-    - ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" "cat > '$DEPLOY_PATH/docker-compose.yml'" < docker-compose.yml
-    - printf "%s" "$ENV_ENCRYPTED" | ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" "cat > '$DEPLOY_PATH/.env.encrypted'"
+    - ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" "cat > '$DEPLOY_PATH/.docker-compose.yml'" < .docker-compose.yml
     - ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" "docker login -u '$CI_REGISTRY_USER' -p '$CI_REGISTRY_PASSWORD' '$CI_REGISTRY' && docker pull '$IMAGE_TAG'"
     - >
-      ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST"
-      "cd '$DEPLOY_PATH' &&
-       docker run --rm
-         -v '$DEPLOY_PATH':/work
-         -w /var/www/html
-         '$IMAGE_TAG'
-         sh -lc 'cp /work/.env.encrypted . &&
-                 php artisan env:decrypt --force --key=\"$ENV_KEY\" --env=\"$DEPLOY_ENV\" &&
-                 cp .env /work/.laravel.env'"
+      printf "%s" "$ENV_ENCRYPTED" | \
+      ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" \
+      "cd '$DEPLOY_PATH' && \
+       docker run --rm -i \
+         -v /dev/shm:/dev/shm \
+         -w /var/www/html \
+         '$IMAGE_TAG' \
+         sh -lc 'cat > .env.encrypted && \
+                 php artisan env:decrypt --force --key=\"$ENV_KEY\" --env=\"$DEPLOY_ENV\" && \
+                 cp .env /dev/shm/.laravel.env && \
+                 rm -f .env .env.encrypted'"
     - >
-      ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST"
-      "cd '$DEPLOY_PATH' &&
-       APP_IMAGE='$IMAGE_TAG' HOST_HTTP_PORT='${HOST_HTTP_PORT:-80}' CONTAINER_HTTP_PORT='${CONTAINER_HTTP_PORT:-8000}' docker compose pull | cat &&
-       APP_IMAGE='$IMAGE_TAG' HOST_HTTP_PORT='${HOST_HTTP_PORT:-80}' CONTAINER_HTTP_PORT='${CONTAINER_HTTP_PORT:-8000}' docker compose up -d | cat &&
-       docker compose exec -T app php artisan migrate --force"
+      ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" \
+      "cd '$DEPLOY_PATH' && \
+       APP_IMAGE='$IMAGE_TAG' APP_ENV_FILE=/dev/shm/.laravel.env HOST_HTTP_PORT='${HOST_HTTP_PORT:-80}' CONTAINER_HTTP_PORT='${CONTAINER_HTTP_PORT:-8000}' docker compose -f .docker-compose.yml up -d | cat && \
+       rm -f /dev/shm/.laravel.env"
+    - >
+      ssh -i ~/.ssh/id_ed25519 "$DEPLOY_USER@$DEPLOY_HOST" \
+      "cd '$DEPLOY_PATH' && docker compose -f .docker-compose.yml exec -T app php artisan migrate --force"
   only:
     - staging


### PR DESCRIPTION
Prevent `.env` secrets from being persisted on the server by decrypting them into a temporary in-memory file (`/dev/shm`) for container setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-8855c978-1260-427e-b704-333ca5ff2aae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8855c978-1260-427e-b704-333ca5ff2aae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

